### PR TITLE
Add TypeScript definitions

### DIFF
--- a/packages/react-router-dom/index.d.ts
+++ b/packages/react-router-dom/index.d.ts
@@ -1,0 +1,89 @@
+// Type definitions for React Router 5.1
+// Project: https://github.com/ReactTraining/react-router
+// Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
+//                 Philip Jackson <https://github.com/p-jackson>
+//                 John Reilly <https://github.com/johnnyreilly>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
+//                 Daniel Nixon <https://github.com/danielnixon>
+//                 Tony Ward <https://github.com/ynotdraw>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { match } from "@zumper/react-router";
+import * as React from "react";
+import * as H from "history";
+
+export {
+  generatePath,
+  Prompt,
+  MemoryRouter,
+  RedirectProps,
+  Redirect,
+  RouteChildrenProps,
+  RouteComponentProps,
+  RouteProps,
+  Route,
+  Router,
+  StaticRouter,
+  SwitchProps,
+  Switch,
+  match,
+  matchPath,
+  withRouter,
+  RouterChildContext,
+  useHistory,
+  useLocation,
+  useParams,
+  useRouteMatch
+} from "@zumper/react-router";
+
+export interface BrowserRouterProps {
+  basename?: string;
+  getUserConfirmation?: (
+    message: string,
+    callback: (ok: boolean) => void
+  ) => void;
+  forceRefresh?: boolean;
+  keyLength?: number;
+}
+export class BrowserRouter extends React.Component<BrowserRouterProps, any> {}
+
+export interface HashRouterProps {
+  basename?: string;
+  getUserConfirmation?: (
+    message: string,
+    callback: (ok: boolean) => void
+  ) => void;
+  hashType?: "slash" | "noslash" | "hashbang";
+}
+export class HashRouter extends React.Component<HashRouterProps, any> {}
+
+export interface LinkProps<S = H.LocationState>
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  component?: React.ComponentType<any>;
+  to:
+    | H.LocationDescriptor<S>
+    | ((location: H.Location<S>) => H.LocationDescriptor<S>);
+  replace?: boolean;
+  innerRef?: React.Ref<HTMLAnchorElement>;
+}
+export class Link<S = H.LocationState> extends React.Component<
+  LinkProps<S>,
+  any
+> {}
+
+export interface NavLinkProps<S = H.LocationState> extends LinkProps<S> {
+  activeClassName?: string;
+  activeStyle?: React.CSSProperties;
+  exact?: boolean;
+  strict?: boolean;
+  isActive?<Params extends { [K in keyof Params]?: string }>(
+    match: match<Params>,
+    location: H.Location<S>
+  ): boolean;
+  location?: H.Location<S>;
+}
+export class NavLink<S = H.LocationState> extends React.Component<
+  NavLinkProps<S>,
+  any
+> {}

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -42,11 +42,14 @@
     "test": "jest",
     "zumper": "yarn build && yarn pack"
   },
+  "types": "index.d.ts",
   "peerDependencies": {
+    "@types/react": "*",
     "react": ">=15"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "@types/history": "*",
     "@zumper/react-router": "^5.1.1-zumper.9",
     "history": "^4.10.1",
     "loose-envify": "^1.4.0",

--- a/packages/react-router/index.d.ts
+++ b/packages/react-router/index.d.ts
@@ -1,0 +1,200 @@
+// Type definitions for React Router 5.1
+// Project: https://github.com/ReactTraining/react-router
+// Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>
+//                 Yuichi Murata <https://github.com/mrk21>
+//                 Václav Ostrožlík <https://github.com/vasek17>
+//                 Nathan Brown <https://github.com/ngbrown>
+//                 Alex Wendland <https://github.com/awendland>
+//                 Kostya Esmukov <https://github.com/KostyaEsmukov>
+//                 John Reilly <https://github.com/johnnyreilly>
+//                 Karol Janyst <https://github.com/LKay>
+//                 Dovydas Navickas <https://github.com/DovydasNavickas>
+//                 Huy Nguyen <https://github.com/huy-nguyen>
+//                 Jérémy Fauvel <https://github.com/grmiade>
+//                 Daniel Roth <https://github.com/DaIgeb>
+//                 Egor Shulga <https://github.com/egorshulga>
+//                 Rahul Raina <https://github.com/rraina>
+//                 Maksim Sharipov <https://github.com/pret-a-porter>
+//                 Duong Tran <https://github.com/t49tran>
+//                 Ben Smith <https://github.com/8enSmith>
+//                 Wesley Tsai <https://github.com/wezleytsai>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
+//                 Nicholas Hehr <https://github.com/HipsterBrown>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from "react";
+import * as H from "history";
+
+// This is the type of the context object that will be passed down to all children of
+// a `Router` component:
+export interface RouterChildContext<
+  Params extends { [K in keyof Params]?: string } = {}
+> {
+  router: {
+    history: H.History;
+    route: {
+      location: H.Location;
+      match: match<Params>;
+    };
+  };
+}
+export interface MemoryRouterProps {
+  initialEntries?: H.LocationDescriptor[];
+  initialIndex?: number;
+  getUserConfirmation?: (
+    message: string,
+    callback: (ok: boolean) => void
+  ) => void;
+  keyLength?: number;
+}
+
+export class MemoryRouter extends React.Component<MemoryRouterProps, any> {}
+
+export interface PromptProps {
+  message: string | ((location: H.Location) => string | boolean);
+  when?: boolean;
+}
+export class Prompt extends React.Component<PromptProps, any> {}
+
+export interface RedirectProps {
+  to: H.LocationDescriptor;
+  push?: boolean;
+  from?: string;
+  path?: string;
+  exact?: boolean;
+  strict?: boolean;
+}
+export class Redirect extends React.Component<RedirectProps, any> {}
+
+export interface StaticContext {
+  statusCode?: number;
+}
+
+export interface RouteComponentProps<
+  Params extends { [K in keyof Params]?: string } = {},
+  C extends StaticContext = StaticContext,
+  S = H.LocationState
+> {
+  history: H.History;
+  location: H.Location<S>;
+  match: match<Params>;
+  staticContext?: C;
+}
+
+export interface RouteChildrenProps<
+  Params extends { [K in keyof Params]?: string } = {},
+  S = H.LocationState
+> {
+  history: H.History;
+  location: H.Location<S>;
+  match: match<Params> | null;
+}
+
+export interface RouteProps {
+  location?: H.Location;
+  component?:
+    | React.ComponentType<RouteComponentProps<any>>
+    | React.ComponentType<any>;
+  render?: (props: RouteComponentProps<any>) => React.ReactNode;
+  children?:
+    | ((props: RouteChildrenProps<any>) => React.ReactNode)
+    | React.ReactNode;
+  path?: string | string[];
+  exact?: boolean;
+  sensitive?: boolean;
+  strict?: boolean;
+}
+export class Route<T extends RouteProps = RouteProps> extends React.Component<
+  T,
+  any
+> {}
+
+export interface RouterProps {
+  history: H.History;
+}
+export class Router extends React.Component<RouterProps, any> {}
+
+export interface StaticRouterContext extends StaticContext {
+  url?: string;
+  action?: "PUSH" | "REPLACE";
+  location?: object;
+}
+export interface StaticRouterProps {
+  basename?: string;
+  location?: string | object;
+  context?: StaticRouterContext;
+}
+
+export class StaticRouter extends React.Component<StaticRouterProps, any> {}
+export interface SwitchProps {
+  children?: React.ReactNode;
+  location?: H.Location;
+}
+export class Switch extends React.Component<SwitchProps, any> {}
+
+export interface match<Params extends { [K in keyof Params]?: string } = {}> {
+  params: Params;
+  isExact: boolean;
+  path: string;
+  url: string;
+}
+
+// Omit taken from https://github.com/Microsoft/TypeScript/issues/28339#issuecomment-467220238
+export type Omit<T, K extends keyof T> = T extends any
+  ? Pick<T, Exclude<keyof T, K>>
+  : never;
+
+export function matchPath<Params extends { [K in keyof Params]?: string }>(
+  pathname: string,
+  props: string | string[] | RouteProps,
+  parent?: match<Params> | null
+): match<Params> | null;
+
+export function generatePath(
+  pattern: string,
+  params?: { [paramName: string]: string | number | boolean | undefined }
+): string;
+
+export type WithRouterProps<
+  C extends React.ComponentType<any>
+> = C extends React.ComponentClass
+  ? { wrappedComponentRef?: React.Ref<InstanceType<C>> }
+  : {};
+
+export interface WithRouterStatics<C extends React.ComponentType<any>> {
+  WrappedComponent: C;
+}
+
+// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
+// they are decorating. Due to this, if you are using @withRouter decorator in your code,
+// you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
+// on a separate line instead of as a decorator.
+export function withRouter<
+  P extends RouteComponentProps<any>,
+  C extends React.ComponentType<P>
+>(
+  component: C & React.ComponentType<P>
+): React.ComponentClass<
+  Omit<P, keyof RouteComponentProps<any>> & WithRouterProps<C>
+> &
+  WithRouterStatics<C>;
+
+export const __RouterContext: React.Context<RouteComponentProps>;
+
+export function useHistory<HistoryLocationState = H.LocationState>(): H.History<
+  HistoryLocationState
+>;
+
+export function useLocation<S = H.LocationState>(): H.Location<S>;
+
+export function useParams<
+  Params extends { [K in keyof Params]?: string } = {}
+>(): { [p in keyof Params]: string };
+
+export function useRouteMatch<
+  Params extends { [K in keyof Params]?: string } = {}
+>(): match<Params>;
+export function useRouteMatch<
+  Params extends { [K in keyof Params]?: string } = {}
+>(path: string | string[] | RouteProps): match<Params> | null;

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -38,11 +38,14 @@
     "test": "jest",
     "zumper": "yarn build && yarn pack"
   },
+  "types": "index.d.ts",
   "peerDependencies": {
+    "@types/react": "*",
     "react": ">=15"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "@types/history": "*",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.0",
     "loose-envify": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,6 +1842,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.3.tgz#856c99cdc1551d22c22b18b5402719affec9839a"
+  integrity sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"


### PR DESCRIPTION
I think putting the types here has a few advantages over putting them in web-shared-packages/packages/types/:

- Easier to keep up-to-date (can update JS and type defs in a single PR)
- Makes the types public, so they can be consumed by anyone who uses `@zumper/react-router`
- We can consume these types across repos, even before devops gets us set up to use Artifactory from CircleCI

See also: [related PR for removing these types from web-shared-packages](https://github.com/zumper/web-shared-packages/pull/5)