### PR TITLE
fix: move @types/history to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "test": "node ./scripts/test.js",
     "zumper": "lerna run --no-bail zumper"
   },
+  "publishConfig": {
+    "registry": "https://zumper.jfrog.io/artifactory/api/npm/npm/"
+  },
   "dependencies": {
     "@babel/core": "^7.6.2",
     "@babel/plugin-proposal-class-properties": "^7.5.5",

--- a/packages/react-router-config/package.json
+++ b/packages/react-router-config/package.json
@@ -4,6 +4,10 @@
   "description": "Static route config matching for React Router",
   "repository": "ReactTraining/react-router",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://zumper.jfrog.io/artifactory/api/npm/npm/"
+  },
   "authors": [
     "Ryan Florence"
   ],

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -4,6 +4,10 @@
   "description": "DOM bindings for React Router",
   "repository": "zumper/react-router",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://zumper.jfrog.io/artifactory/api/npm/npm/"
+  },
   "authors": [
     "Michael Jackson",
     "Ryan Florence"

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -45,12 +45,12 @@
   },
   "types": "index.d.ts",
   "peerDependencies": {
+    "@types/history": "*",
     "@types/react": "*",
     "react": ">=15"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@types/history": "*",
     "@zumper/react-router": "^5.1.2-zumper.11",
     "history": "^4.10.1",
     "loose-envify": "^1.4.0",

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -4,6 +4,10 @@
   "description": "React Native bindings for React Router",
   "repository": "ReactTraining/react-router",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://zumper.jfrog.io/artifactory/api/npm/npm/"
+  },
   "authors": [
     "Michael Jackson",
     "Ryan Florence"

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -41,12 +41,12 @@
   },
   "types": "index.d.ts",
   "peerDependencies": {
+    "@types/history": "*",
     "@types/react": "*",
     "react": ">=15"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@types/history": "*",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.0",
     "loose-envify": "^1.4.0",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -4,6 +4,10 @@
   "description": "Declarative routing for React",
   "repository": "zumper/react-router",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://zumper.jfrog.io/artifactory/api/npm/npm/"
+  },
   "authors": [
     "Michael Jackson",
     "Ryan Florence"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,11 +1842,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/history@*":
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.3.tgz#856c99cdc1551d22c22b18b5402719affec9839a"
-  integrity sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"


### PR DESCRIPTION
To fix [this](https://app.circleci.com/pipelines/github/zumper/web-shared-packages/3447/workflows/ee0ce53d-629e-4cff-b1d0-fc56408cc5db/jobs/5023?invite=true#step-107-52):

```
lerna ERR! yarn run build exited 1 in '@zcode/history-middleware'
lerna ERR! yarn run build stdout:
src/actions.ts(47,14): error TS2742: The inferred type of 'push' cannot be named without a reference to
'@zumper/react-router/node_modules/@types/history'. This is likely not portable. A type annotation is
necessary.
src/actions.ts(52,14): error TS2742: The inferred type of 'replace' cannot be named without a reference to
'@zumper/react-router/node_modules/@types/history'. This is likely not portable. A type annotation is
necessary.
```

Because `@types/history` was listed as a dependency of `@zumper/react-router`/`-dom`, we ended up with a separate copy of it in `web-shared-packages/node_modules/@zumper/react-router/node_modules/@types/history/`. With it in `peerDependencies`, it'll use the same copy of `@types/history` that the rest of `web-shared-packages` is using.